### PR TITLE
Improve the example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
+dist/*
 node_modules
 package-lock.json
-bundle.js

--- a/hello-world.js
+++ b/hello-world.js
@@ -1,8 +1,8 @@
-var Component = require("can-component");
-var DefineMap = require("can-define/map/map");
-var stache = require("can-stache");
+import Component from "can-component";
+import DefineMap from "can-define/map/map";
+import stache from "can-stache";
 
-var HelloWorldVM = DefineMap.extend({
+const HelloWorldVM = DefineMap.extend({
   visible: { default: false },
   message: { default: "Hello There!" }
 });

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Getting Started With Webpack | CanJS</title>
+    <title>CanJS and webpack</title>
   </head>
   <body>
-    <script src="./bundle.js" type="text/javascript"></script>
+    <script src="./dist/bundle.js" type="text/javascript"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,9 +1,9 @@
-var DefineMap = require("can-define/map/map");
-var stache = require("can-stache");
-var template = stache(require('raw-loader!./main.stache'));
-
+import DefineMap from "can-define/map/map";
+import stache from "can-stache";
+import rawTemplate from "raw-loader!./main.stache";
 import "./hello-world";
 
-var data = new DefineMap({ message: "Hello World" });
+const data = new DefineMap({ message: "Hello World" });
+const template = stache(rawTemplate);
 
 document.body.appendChild(template(data));

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
   ],
   "main": "main.js",
   "scripts": {
+    "build": "webpack --progress -p main.js -o dist/bundle.production.js",
     "clean": "rm -rf bundle.js",
-    "develop": "webpack --progress -d --watch main.js bundle.js",
-    "build": "webpack --progress -p main.js bundle.js"
+    "develop": "webpack --progress -d --watch main.js -o dist/bundle.js",
+    "start": "http-server"
   },
   "dependencies": {
     "can-component": "^4.0.1",
@@ -35,7 +36,9 @@
     "can-stache-bindings": "^4.0.4"
   },
   "devDependencies": {
+    "http-server": "^0.11.1",
     "raw-loader": "^0.5.1",
-    "webpack": "^3.10.0"
+    "webpack": "^4.0.0",
+    "webpack-cli": "^2.0.12"
   }
 }

--- a/production.html
+++ b/production.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CanJS and webpack (production)</title>
+  </head>
+  <body>
+    <script src="./dist/bundle.production.js"></script>
+  </body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,23 @@
-# webpack-example
+# CanJS & webpack example
 
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.md)
 [![Travis build status](https://travis-ci.org/canjs/webpack-example.svg?branch=master)](https://travis-ci.org/canjs/webpack-example)
 [![Greenkeeper badge](https://badges.greenkeeper.io/canjs/webpack-example.svg)](https://greenkeeper.io/)
 
-1. Clone this repo.
-2. Run `npm install`
-3. Run `npm run develop`
-3. Start an `http-server` in the root directory.
-4. Open in your browser.
+## Getting started
 
-## Production Build
+1. Clone this repo
+2. Run `npm install` to install all the dependencies
+3. Run `npm run develop` to start webpack
+4. Run `npm start` to start an http server
+5. Open `index.html` in your browser
 
-1. run `npm run build`
-2. Start an `http-server` in the root directory.
-3. Open in your browser.
+## Build for production
+
+To build the application into a production bundle, run:
+
+```
+npm run build
+```
+
+You can now open `production.html` in your browser.


### PR DESCRIPTION
- Install http-server and add an npm start script to make it even easier
- Create a production html file and build a different bundle for production
- Upgrade to webpack 4
- Use ES6 syntax in the example code
- Flesh out the README